### PR TITLE
Support for >2 nested subgroups in destination path

### DIFF
--- a/gitlab_migrate/connection.py
+++ b/gitlab_migrate/connection.py
@@ -90,15 +90,18 @@ def find_group(connection, group, statistics=False):
     if '/' in group:
         tokens = group.split('/')
         current_group = None
+        base_group = None
         for search_for in tokens:
             if current_group is None:
                 current_group = connection.groups.list(
                     search=search_for, statistics=statistics, include_subgroups=True
                 )[0]
+                base_group = current_group
             else:
-                current_group = current_group.subgroups.list(
+                current_group = base_group.subgroups.list(
                     search=search_for, statistics=statistics, include_subgroups=True
                 )[0]
+                base_group = connection.groups.get(current_group.id)
         # full API access only through groups.get
         current_group = connection.groups.get(current_group.id)
         return current_group


### PR DESCRIPTION
Pulling an object out of a gitlab.v4.objects.Group's subgroup property returns a gitlab.v4.objects.GroupSubgroup object, which is not a subclass of Group, and thus doesn't have a subgroup property.  This will cause the code to break if the destination is more than 2 groups deep.

To solve this the id property of the Subgroup can be used to pull out an actual group object object out with groups.get, then querying the subgroups of that object.